### PR TITLE
fix: Improve Mermaid diagram arrow visibility on dark backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ flowchart LR
     style Team fill:#f1f8e9,stroke:#558b2f,stroke-width:2px,color:#000
     style Support fill:#fce4ec,stroke:#c2185b,stroke-width:2px,color:#000
     
-    linkStyle default stroke:#333,stroke-width:2px,fill:none
-    linkStyle 5,6,7,8 stroke:#666,stroke-width:2px,fill:none,stroke-dasharray: 5 5
+    linkStyle default stroke:#666,stroke-width:2px,fill:none
+    linkStyle 5,6,7,8 stroke:#888,stroke-width:2px,fill:none,stroke-dasharray: 5 5
 ```
 
 **The Flow Explained:**


### PR DESCRIPTION
- Changed solid arrows from #333 to #666 for better visibility
- Changed dashed arrows from #666 to #888 for better contrast
- Arrows now visible on both light and dark GitHub themes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>